### PR TITLE
Reduce Redis calls GET/MGET

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdns-razor
-version: 0.5.2
+version: 0.6.0
 
 dependencies:
   redis:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdns-razor
-version: 0.6.0
+version: 0.6.1
 
 dependencies:
   redis:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: pdns-razor
-version: 0.6.1
+version: 0.6.2
 
 dependencies:
   redis:

--- a/spec/razor_geoip_spec.cr
+++ b/spec/razor_geoip_spec.cr
@@ -70,30 +70,36 @@ describe "GeoIP" do
     razor.data_from_redis("A", qname, "193.219.39.234", options, {
       :continent => "eu",
       :country   => "lt",
+      :route     => "lt-bnk1.routes.example.org",
     }).should eq(["10.0.1.1"])
     razor.data_from_redis("AAAA", qname, "2a03:1960::", options, {
       :continent => "eu",
       :country   => "lt",
+      :route     => "lt-bnk1.routes.example.org",
     }).should eq(["2a02:478:1::1"])
 
     # United Kingdom gets IPs from lt-bnk2.routes.examle.org pool
     razor.data_from_redis("A", qname, "31.170.164.0", options, {
       :continent => "eu",
       :country   => "gb",
+      :route     => "lt-bnk2.routes.example.org",
     }).should eq(["10.0.1.2"])
     razor.data_from_redis("AAAA", qname, "2a02:8800::", options, {
       :continent => "eu",
       :country   => "gb",
+      :route     => "lt-bnk2.routes.example.org",
     }).should eq(["2a02:478:1::2"])
 
     # United States gets IPs from us-phx1.routes.example.org pool
     razor.data_from_redis("A", qname, "32.47.115.0", options, {
       :continent => "na",
       :country   => "us",
+      :route     => "us-phx1.routes.example.org",
     }).should eq(["10.0.2.1"])
     razor.data_from_redis("AAAA", qname, "2a0d:d900::", options, {
       :continent => "na",
       :country   => "us",
+      :route     => "us-phx1.routes.example.org",
     }).should eq(["2a02:4780:2::1"])
 
     # Others gets IPs from cdn.example.org pool
@@ -130,6 +136,7 @@ describe "GeoIP" do
     razor.data_from_redis("A", qname, "32.47.115.0", options, {
       :continent => "na",
       :country   => "us",
+      :route     => "us-phx1.routes.example.org",
     }).should eq(["10.0.2.1"])
   end
 
@@ -153,6 +160,7 @@ describe "GeoIP" do
     razor.data_from_redis("A", qname, "66.249.82.0", options, {
       :continent => "as",
       :country   => nil,
+      :route     => "sg-nme1.routes.example.org",
     }).should eq(["10.0.3.1"])
   end
 

--- a/spec/razor_geoip_spec.cr
+++ b/spec/razor_geoip_spec.cr
@@ -67,16 +67,34 @@ describe "GeoIP" do
     redis.del(qname)
 
     # Lithuania gets IPs from lt-bnk1.routes.example.org pool
-    razor.data_from_redis("A", qname, "193.219.39.234", options).should eq(["10.0.1.1"])
-    razor.data_from_redis("AAAA", qname, "2a03:1960::", options).should eq(["2a02:478:1::1"])
+    razor.data_from_redis("A", qname, "193.219.39.234", options, {
+      :continent => "eu",
+      :country   => "lt",
+    }).should eq(["10.0.1.1"])
+    razor.data_from_redis("AAAA", qname, "2a03:1960::", options, {
+      :continent => "eu",
+      :country   => "lt",
+    }).should eq(["2a02:478:1::1"])
 
     # United Kingdom gets IPs from lt-bnk2.routes.examle.org pool
-    razor.data_from_redis("A", qname, "31.170.164.0", options).should eq(["10.0.1.2"])
-    razor.data_from_redis("AAAA", qname, "2a02:8800::", options).should eq(["2a02:478:1::2"])
+    razor.data_from_redis("A", qname, "31.170.164.0", options, {
+      :continent => "eu",
+      :country   => "gb",
+    }).should eq(["10.0.1.2"])
+    razor.data_from_redis("AAAA", qname, "2a02:8800::", options, {
+      :continent => "eu",
+      :country   => "gb",
+    }).should eq(["2a02:478:1::2"])
 
     # United States gets IPs from us-phx1.routes.example.org pool
-    razor.data_from_redis("A", qname, "32.47.115.0", options).should eq(["10.0.2.1"])
-    razor.data_from_redis("AAAA", qname, "2a0d:d900::", options).should eq(["2a02:4780:2::1"])
+    razor.data_from_redis("A", qname, "32.47.115.0", options, {
+      :continent => "na",
+      :country   => "us",
+    }).should eq(["10.0.2.1"])
+    razor.data_from_redis("AAAA", qname, "2a0d:d900::", options, {
+      :continent => "na",
+      :country   => "us",
+    }).should eq(["2a02:4780:2::1"])
 
     # Others gets IPs from cdn.example.org pool
     razor.data_from_redis("A", qname, "102.164.115.0", options).first.to_s.should match(/(192\.168\.0\.\d+|10.0.0.1)/)
@@ -90,7 +108,7 @@ describe "GeoIP" do
   it "Check if specific domains are sticked to an arbitrary PoP" do
     qname = "donatas1.net.cdn.example.org"
     extra = {
-      :zone => "lt-bnk2.routes.example.org"
+      :zone => "lt-bnk2.routes.example.org",
     }
     razor_test = RazorTest.new
     redis_unixsocket = razor_test.redis_unixsocket
@@ -109,7 +127,10 @@ describe "GeoIP" do
     redis = Redis.new(unixsocket: redis_unixsocket)
     razor = RazorTest.new.razor
     options = razor.mandatory_dns_options(qname)
-    razor.data_from_redis("A", qname, "32.47.115.0", options).should eq(["10.0.2.1"])
+    razor.data_from_redis("A", qname, "32.47.115.0", options, {
+      :continent => "na",
+      :country   => "us",
+    }).should eq(["10.0.2.1"])
   end
 
   it "Check if we respond to a default zone if GeoIP data found, but no continent/country" do
@@ -129,7 +150,10 @@ describe "GeoIP" do
     redis = Redis.new(unixsocket: redis_unixsocket)
     razor = RazorTest.new.razor
     options = razor.mandatory_dns_options(qname)
-    razor.data_from_redis("A", qname, "66.249.82.0", options).should eq(["10.0.3.1"])
+    razor.data_from_redis("A", qname, "66.249.82.0", options, {
+      :continent => "as",
+      :country   => nil,
+    }).should eq(["10.0.3.1"])
   end
 
   it "Check if mandatory DNS record types are returned correctly" do

--- a/spec/razor_geoip_spec.cr
+++ b/spec/razor_geoip_spec.cr
@@ -89,14 +89,17 @@ describe "GeoIP" do
 
   it "Check if specific domains are sticked to an arbitrary PoP" do
     qname = "donatas1.net.cdn.example.org"
+    extra = {
+      :zone => "lt-bnk2.routes.example.org"
+    }
     razor_test = RazorTest.new
     redis_unixsocket = razor_test.redis_unixsocket
     redis = Redis.new(unixsocket: redis_unixsocket)
-    redis.set(qname, "lt-bnk2.routes.example.org")
+    redis.set(qname, extra[:zone])
     razor = RazorTest.new.razor
     options = razor.mandatory_dns_options(qname)
-    razor.data_from_redis("A", qname, "32.47.115.0", options).should eq(["10.0.1.2"])
-    razor.data_from_redis("AAAA", qname, "2a06:4b80::", options).should eq(["2a02:478:1::2"])
+    razor.data_from_redis("A", qname, "32.47.115.0", options, extra).should eq(["10.0.1.2"])
+    razor.data_from_redis("AAAA", qname, "2a06:4b80::", options, extra).should eq(["2a02:478:1::2"])
   end
 
   it "Check if we don't crash and respond if quering a default zone" do

--- a/spec/razor_iprange_random_spec.cr
+++ b/spec/razor_iprange_random_spec.cr
@@ -31,6 +31,9 @@ describe "IP range random generation from the list" do
 
   it "Create specific routes (PoP) in Redis using IPv4/IPv6 ranges" do
     qname = "donatas.net.cdn.example.org"
+    extra = {
+      :zone => "lt-bnk3.routes.example.org"
+    }
     razor_test = RazorTest.new
     redis_unixsocket = razor_test.redis_unixsocket
     razor_zone = razor_test.razor_zone
@@ -39,8 +42,8 @@ describe "IP range random generation from the list" do
     options = razor.mandatory_dns_options(qname)
     redis.sadd("lt-bnk3.routes.example.org:A", "192.168.0.0/24")
     redis.sadd("lt-bnk3.routes.example.org:AAAA", "2a02:4780:100::/48")
-    redis.set(qname, "lt-bnk3.routes.example.org")
-    razor.data_from_redis("A", qname, "102.164.115.0", options).first.to_s.should contain("192\.168\.0\.")
-    razor.data_from_redis("AAAA", qname, "2a06:4b80::", options).first.to_s.should contain("2a02:4780:0100:")
+    redis.set(qname, extra[:zone])
+    razor.data_from_redis("A", qname, "102.164.115.0", options, extra).first.to_s.should contain("192\.168\.0\.")
+    razor.data_from_redis("AAAA", qname, "2a06:4b80::", options, extra).first.to_s.should contain("2a02:4780:0100:")
   end
 end

--- a/spec/razor_iprange_random_spec.cr
+++ b/spec/razor_iprange_random_spec.cr
@@ -32,7 +32,7 @@ describe "IP range random generation from the list" do
   it "Create specific routes (PoP) in Redis using IPv4/IPv6 ranges" do
     qname = "donatas.net.cdn.example.org"
     extra = {
-      :zone => "lt-bnk3.routes.example.org"
+      :zone => "lt-bnk3.routes.example.org",
     }
     razor_test = RazorTest.new
     redis_unixsocket = razor_test.redis_unixsocket
@@ -43,7 +43,7 @@ describe "IP range random generation from the list" do
     redis.sadd("lt-bnk3.routes.example.org:A", "192.168.0.0/24")
     redis.sadd("lt-bnk3.routes.example.org:AAAA", "2a02:4780:100::/48")
     redis.set(qname, extra[:zone])
-    razor.data_from_redis("A", qname, "102.164.115.0", options, extra).first.to_s.should contain("192\.168\.0\.")
+    razor.data_from_redis("A", qname, "102.164.115.0", options, extra).first.to_s.should contain("192.168.0.")
     razor.data_from_redis("AAAA", qname, "2a06:4b80::", options, extra).first.to_s.should contain("2a02:4780:0100:")
   end
 end

--- a/spec/razor_txt_tracing_spec.cr
+++ b/spec/razor_txt_tracing_spec.cr
@@ -8,6 +8,7 @@ describe "Tracing" do
     razor.data_from_redis("TXT", qname, "32.47.115.0", options, {
       :continent => "na",
       :country   => "us",
+      :route     => "us-phx1.routes.example.org",
     }).should eq(["Razor/32.47.115.0 (na:us)/10.0.2.1"])
   end
 

--- a/spec/razor_txt_tracing_spec.cr
+++ b/spec/razor_txt_tracing_spec.cr
@@ -5,13 +5,16 @@ describe "Tracing" do
     qname = "donatas2.net.cdn.example.org"
     razor = RazorTest.new.razor
     options = razor.mandatory_dns_options(qname)
-    razor.data_from_redis("TXT", qname, "32.47.115.0", options).should eq(["Razor/32.47.115.0 (NA:US)/10.0.2.1"])
+    razor.data_from_redis("TXT", qname, "32.47.115.0", options, {
+      :continent => "na",
+      :country   => "us",
+    }).should eq(["Razor/32.47.115.0 (na:us)/10.0.2.1"])
   end
 
   it "Check if source and destinationed IPs are returned from EDNS" do
     qname = "donatas1.net.cdn.example.org"
     extra = {
-      :zone => "lt-bnk2.routes.example.org"
+      :zone => "lt-bnk2.routes.example.org",
     }
     razor = RazorTest.new.razor
     options = razor.mandatory_dns_options(qname)

--- a/spec/razor_txt_tracing_spec.cr
+++ b/spec/razor_txt_tracing_spec.cr
@@ -10,8 +10,11 @@ describe "Tracing" do
 
   it "Check if source and destinationed IPs are returned from EDNS" do
     qname = "donatas1.net.cdn.example.org"
+    extra = {
+      :zone => "lt-bnk2.routes.example.org"
+    }
     razor = RazorTest.new.razor
     options = razor.mandatory_dns_options(qname)
-    razor.data_from_redis("TXT", qname, "32.47.115.0", options).should eq(["Razor/32.47.115.0/10.0.1.2"])
+    razor.data_from_redis("TXT", qname, "32.47.115.0", options, extra).should eq(["Razor/32.47.115.0/10.0.1.2"])
   end
 end


### PR DESCRIPTION
Ran resperf/dnsperf multiple times.

Before:
```
Statistics:

  Queries sent:         245386
  Queries completed:    181256
  Queries lost:         64130
  Response codes:       NOERROR 181256 (100.00%)
  Reconnection(s):      0
  Run time (s):         63.088010
  Maximum throughput:   14518.000000 qps
  Lost at that point:   38.55%
```

After:
```
Statistics:

  Queries sent:         323395
  Queries completed:    259334
  Queries lost:         64061
  Response codes:       NOERROR 259334 (100.00%)
  Reconnection(s):      0
  Run time (s):         65.779803
  Maximum throughput:   18412.000000 qps
  Lost at that point:   28.85%
```