### PR TITLE
logs: Skip no continent/country found logs in prod

### DIFF
--- a/src/razor.cr
+++ b/src/razor.cr
@@ -179,7 +179,9 @@ class Razor
       continent = rec.continent.code
       country = rec.country.iso_code
       if !continent && !country
-        @log.warn("No continent/country found for #{ip}")
+        if @debug
+          @log.warn("No continent/country found for #{ip}")
+        end
         return nil, nil
       end
       return continent, country


### PR DESCRIPTION
This log line takes a lot of CDN logs amount
and is of little use. We can skip it.